### PR TITLE
Use expl3 in difficult macro definitions

### DIFF
--- a/pandoc-to-markdown.tex
+++ b/pandoc-to-markdown.tex
@@ -4,33 +4,34 @@
 \def\pandocBlocksep{\markdownRendererInterblockSeparator}%
 
 %% Block elements
-\def\pandocCodeBlock#1#2{%
-  \ifx\relax#2\relax
-    \markdownRendererInputVerbatim{#1}%
-  \else
-    \markdownRendererInputFencedCode{#1}{#2}%
-  \fi
-}
+\ExplSyntaxOn
+\def\pandocCodeBlock#1#2
+  {
+    \tl_if_empty:nTF
+      { #2 }
+      { \markdownRendererInputVerbatim { #1 } }
+      { \markdownRendererInputFencedCode { #1 } { #2 } }
+  }
+\ExplSyntaxOff
 \def\pandocBulletListBegin{\markdownRendererUlBegin}%
 \def\pandocBulletListItemBegin{\markdownRendererUlItem}%
 \def\pandocBulletListItemEnd{\markdownRendererUlItemEnd}%
 \def\pandocBulletListEnd{\markdownRendererUlEnd}%
-\def\pandocHeader#1#2{%
-  \ifcase#1\relax
-  \or
-    \markdownRendererHeadingOne{#2}%
-  \or
-    \markdownRendererHeadingTwo{#2}%
-  \or
-    \markdownRendererHeadingThree{#2}%
-  \or
-    \markdownRendererHeadingFour{#2}%
-  \or
-    \markdownRendererHeadingFive{#2}%
-  \or
-    \markdownRendererHeadingSix{#2}%
-  \fi
-}
+\ExplSyntaxOn
+\def\pandocHeader#1#2
+  {
+    \int_case:nn
+      { #1 }
+      {
+        { 1 } { \markdownRendererHeadingOne { #2 } }
+        { 2 } { \markdownRendererHeadingTwo { #2 } }
+        { 3 } { \markdownRendererHeadingThree { #2 } }
+        { 4 } { \markdownRendererHeadingFour { #2 } }
+        { 5 } { \markdownRendererHeadingFive { #2 } }
+        { 6 } { \markdownRendererHeadingSix { #2 } }
+      }
+  }
+\ExplSyntaxOff
 \def\pandocHorizontalRule{\markdownRendererHorizontalRule}%
 
 %% Inline elements


### PR DESCRIPTION
The markdown package is steadily replacing low-level TeX code with high-level expl3 code (see https://github.com/Witiko/markdown/issues/96, https://github.com/Witiko/markdown/issues/118, https://github.com/Witiko/markdown/issues/119), which is easier to read and does not suffer many of the vulnerabilities associated with low-level TeX code.

This pull request rewrites two of the more difficult macro definitions in `pandoc-to-markdown.tex` using the [`\tl_if_empty:nTF`][1] and [`\int_case:nn`][2] expl3 commands and closes a vulnerability in `\pandocCodeBlock`, which allows code injection when `#2` starts with `\relax`.

 [1]: http://mirrors.ctan.org/macros/latex/contrib/l3kernel/interface3.pdf#page=114
 [2]: http://mirrors.ctan.org/macros/latex/contrib/l3kernel/interface3.pdf#page=170