### PR TITLE
Use a single pass over input in `escape()`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
       - run: latexmk -shell-escape -lualatex example-man-pandoc.tex
       - run: latexmk -shell-escape -lualatex example-man-leapp.tex
       - uses: marvinpinto/action-automatic-releases@latest
+        if: github.ref == 'refs/heads/main'
         with:
           title: The latest converted example document
           automatic_release_tag: latest

--- a/pandoc-to-markdown.lua
+++ b/pandoc-to-markdown.lua
@@ -17,24 +17,23 @@ setmetatable(_G, meta)
 
 function escape(s)
   -- TODO handle all special characters, deduplicate code
-  s = string.gsub(s, "\\", "\\\\")
-  -- TODO avoid the dummy
-  s = string.gsub(s, "{", "!!DUMMY!!")
-  s = string.gsub(s, "}", "\\textbraceright{}")
-  s = string.gsub(s, "!!DUMMY!!", "\\textbraceleft{}")
-  s = string.gsub(s, "%[", "\\lbrack{}")
-  s = string.gsub(s, "]", "\\rbrack{}")
-  s = string.gsub(s, "%<", "\\textless{}")
-  s = string.gsub(s, "%>", "\\textgreater{}")
-  s = string.gsub(s, "%|", "\\textbar{}")
-  s = string.gsub(s, "_", "\\_")
-  s = string.gsub(s, "#", "\\#")
-  s = string.gsub(s, "&", "\\&")
-  s = string.gsub(s, "~", "\\~{}")
-  s = string.gsub(s, "`", "\\`{}")
-  s = string.gsub(s, "%^", "\\^{}")
-  s = string.gsub(s, "%%", "\\%%")
-  s = string.gsub(s, "%$", "\\$")
+  s = string.gsub(s, "[\\{}%|_#&~%^%%%$]", function(c)
+    local s
+    if     c == "\\" then s = "\\textbackslash{}"
+    elseif c == "{"  then s = "\\textbraceleft{}"
+    elseif c == "}"  then s = "\\textbraceright{}"
+    elseif c == "|"  then s = "\\textbar{}"
+    elseif c == "_"  then s = "\\textunderscore{}"
+    elseif c == "#"  then s = "\\#{}"
+    elseif c == "&"  then s = "\\&{}"
+    elseif c == "~"  then s = "\\textasciitilde{}"
+    elseif c == "^"  then s = "\\textasciicircum{}"
+    elseif c == "%"  then s = "\\%{}"
+    elseif c == "$"  then s = "\\${}"
+    else                  s = c
+    end
+    return s
+  end)
   return s
 end
 


### PR DESCRIPTION
The `escape()` function in `pandoc-to-markdown.lua` uses several passes over the input, which allows undesirable recursive replacements and slows things down. Furthermore, the function contains typos (`string.gsub(s, "%%", "\\%%")` instead of `string.gsub(s, "%%", "\\%")`), escapes characters that are not [special][1] (`` ` ``, `[`, `]`, `<`, `>`), and uses a mixture of plain TeX (`\^{}`) and LaTeX (`\textless{}`) commands.

This PR uses a single call of `string.gsub()` to replace all special characters. It fixes the typos, disables the replacement of characters that are not special, and consistently uses LaTeX commands. Future changes should map the specials to high-level `\pandoc*` macros, which would then expand either to [Markdown's special character renderers][2].

 [1]: https://en.wikibooks.org/wiki/TeX/catcode
 [2]: https://witiko.github.io/markdown/#special-character-renderers