### PR TITLE
Move LaTeX macro definitions to `pandoc-to-markdown.sty`

### DIFF
--- a/pandoc-to-markdown.sty
+++ b/pandoc-to-markdown.sty
@@ -11,6 +11,10 @@
 \RequirePackage[normalem]{ulem}
 \renewcommand\pandocStrikeout[1]{\sout{#1}}
 \renewcommand\pandocUnderline[1]{\uline{#1}}
+\renewcommand\pandocSmallCaps{\textsc}
+\renewcommand\pandocSubscript{\textsubscript}
+\renewcommand\pandocSuperscript{\textsuperscript}
+\renewcommand\pandocNote{\footnote}
 
 \def\pandocFormat{markdown}
 \define@key{pandoc-to-markdown}{format}{%

--- a/pandoc-to-markdown.sty
+++ b/pandoc-to-markdown.sty
@@ -9,8 +9,8 @@
 
 %% Inline elements
 \RequirePackage[normalem]{ulem}
-\renewcommand\pandocStrikeout[1]{\sout{#1}}
-\renewcommand\pandocUnderline[1]{\uline{#1}}
+\renewcommand\pandocStrikeout{\sout}
+\renewcommand\pandocUnderline{\uline}
 \renewcommand\pandocSmallCaps{\textsc}
 \renewcommand\pandocSubscript{\textsubscript}
 \renewcommand\pandocSuperscript{\textsuperscript}

--- a/pandoc-to-markdown.tex
+++ b/pandoc-to-markdown.tex
@@ -46,15 +46,15 @@
 \def\pandocUnderline#1{#1}%
 \def\pandocStrong{\markdownRendererStrongEmphasis}%
 \def\pandocStrikeout#1{#1}%
-\def\pandocSubscript{\textsubscript}%
-\def\pandocSuperscript{\textsuperscript}%
-\def\pandocSmallCaps{\textsc}%
+\def\pandocSubscript#1{#1}%
+\def\pandocSuperscript#1{#1}%
+\def\pandocSmallCaps#1{#1}%
 \def\pandocSingleQuoted#1{`#1'}%
 \def\pandocDoubleQuoted#1{``#1''}%
 \def\pandocCode{\markdownRendererCodeSpan}%
 \def\pandocSpace{ }%
 \def\pandocInlineMath#1{$#1$}%
-\def\pandocNote{\footnote}%
+\def\pandocNote#1{#1}%
 
 %% Special characters
 \def\pandocRendererAmpersand{\markdownRendererAmpersand}%


### PR DESCRIPTION
This pull request moves definitions of `\pandoc{SmallCaps,Subscript,Superscript,Note}` to `pandoc-to-markdown.sty`, because they rely on LaTeX. Additionally, the pull request makes definitions of `\pandoc{Strikeout,Underline}` pointfree.