### PR TITLE
Explicitly require `shellesc` package

### DIFF
--- a/pandoc-to-markdown.sty
+++ b/pandoc-to-markdown.sty
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{pandoc-to-markdown}[2021/01/18 package pandoc-to-markdown]
+\ProvidesPackage{pandoc-to-markdown}[2022/10/11 package pandoc-to-markdown]
 
 \RequirePackage{markdown}
 \input"pandoc-to-markdown.tex"
@@ -50,6 +50,7 @@
 \def\pandocAuxDir{_pandoc_\jobname}
 
 % Document command definitions
+\RequirePackage{shellesc}  % Polyfill \write18 in LuaTeX
 \newcommand\pandocInput[2][]{%
   \setkeys{pandoc-to-markdown}{#1}%
   \directlua{local kpse = require("kpse")


### PR DESCRIPTION
As discussed privatly at Matrix.org, `\write18` working in LuaTeX is a happy accident. In LuaTeX, the `\write18` primitive has been deprecated and removed in favor of the `os.execute()` Lua built-in. The [shellesc LaTeX package][1] polyfills `\write18`, so that it works even in LuaTeX. Shellesc is being loaded transitively by other LaTeX packages, which means that it could cease being loaded at any point in the future, breaking our code. To prevent future breakage, we should make our reliance on shellesc known. This pull request explicitly loads shellesc and denotes why we need it in a comment.

 [1]: https://www.ctan.org/pkg/shellesc