### PR TITLE
Replace `\markdownRendererHorizontalRule` with `\markdownRendererThematicBreak`

### DIFF
--- a/examples/markdown-panda.tex
+++ b/examples/markdown-panda.tex
@@ -1,9 +1,9 @@
 \documentclass{article}
+\usepackage{pandoc-to-markdown}
 % slightly shrink margins
 \usepackage[a4paper, margin=4cm]{geometry}
 % enable syntax highlighting
 \usepackage{minted}
-\usepackage{pandoc-to-markdown}
 % add bibliography (for citations)
 \usepackage{biblatex}
 \addbibresource{markdown-panda.bib}

--- a/pandoc-to-markdown.tex
+++ b/pandoc-to-markdown.tex
@@ -54,7 +54,7 @@
       }
   }
 \ExplSyntaxOff
-\def\pandocHorizontalRule{\markdownRendererHorizontalRule}%
+\def\pandocHorizontalRule{\markdownRendererThematicBreak}%
 \def\pandocDivBegin{}%
 \def\pandocDivEnd{}%
 \def\pandocDisplayMath#1{\[#1\]}%

--- a/pandoc-to-markdown.tex
+++ b/pandoc-to-markdown.tex
@@ -5,14 +5,18 @@
 
 %% Block elements
 \ExplSyntaxOn
-\def\pandocCodeBlock#1#2
+\cs_new:Npn
+  \pandocCodeBlock
+  #1 #2
   {
     \tl_if_empty:nTF
       { #2 }
       { \markdownRendererInputVerbatim { #1 } }
       { \markdownRendererInputFencedCode { #1 } { #2 } }
   }
-\def\pandocRawBlock#1#2
+\cs_new:Npn
+  \pandocRawBlock
+  #1 #2
   {
     \tl_if_eq:nnT
       { #1 }
@@ -40,7 +44,9 @@
 \def\pandocDefinitionListItemEnd{\markdownRendererDlItemEnd}%
 \def\pandocDefinitionListEnd{\markdownRendererDlEnd}%
 \ExplSyntaxOn
-\def\pandocHeader#1#2
+\cs_new:Npn
+  \pandocHeader
+  #1 #2
   {
     \int_case:nn
       { #1 }
@@ -53,7 +59,8 @@
         { 6 } { \markdownRendererHeadingSix { #2 } }
       }
   }
-\def\pandocHorizontalRule
+\cs_new:Npn
+  \pandocHorizontalRule
   {
     \cs_if_exist_use:NF
       \markdownRendererThematicBreak
@@ -82,7 +89,9 @@
 \def\pandocLineBreak{\markdownRendererLineBreak}%
 \def\pandocInlineMath#1{$#1$}%
 \ExplSyntaxOn
-\def\pandocRawInline#1#2
+\cs_new:Npn
+  \pandocRawInline
+  #1 #2
   {
     \tl_if_eq:nnT
       { #1 }

--- a/pandoc-to-markdown.tex
+++ b/pandoc-to-markdown.tex
@@ -53,8 +53,13 @@
         { 6 } { \markdownRendererHeadingSix { #2 } }
       }
   }
+\def\pandocHorizontalRule
+  {
+    \cs_if_exist_use:NF
+      \markdownRendererThematicBreak
+      \markdownRendererHorizontalRule
+  }
 \ExplSyntaxOff
-\def\pandocHorizontalRule{\markdownRendererThematicBreak}%
 \def\pandocDivBegin{}%
 \def\pandocDivEnd{}%
 \def\pandocDisplayMath#1{\[#1\]}%


### PR DESCRIPTION
Closes #14.